### PR TITLE
[feat] 007-APPLICATION-CONFIG

### DIFF
--- a/src/main/java/com/zerobase/convpay/UserClient.java
+++ b/src/main/java/com/zerobase/convpay/UserClient.java
@@ -1,5 +1,6 @@
 package com.zerobase.convpay;
 
+import com.zerobase.convpay.config.ApplicationConfig;
 import com.zerobase.convpay.dto.PayCancelRequest;
 import com.zerobase.convpay.dto.PayCancelResponse;
 import com.zerobase.convpay.dto.PayRequest;
@@ -12,10 +13,12 @@ public class UserClient {
     public static void main(String[] args) {
         //'사용자' -> 편결이 -> 머니
 
-        ConveniencePayService conveniencePayService = new ConveniencePayService();
+        ApplicationConfig applicationConfig = new ApplicationConfig();
+        //ConveniencePayService conveniencePayService = new ConveniencePayService();
+        ConveniencePayService conveniencePayService = applicationConfig.conveniencePayServiceDiscountPayMethod();
 
         // G25, 1000원 결제
-        PayRequest payRequest = new PayRequest(PayMethodType.CARD, ConvenienceType.G25, 1000);
+        PayRequest payRequest = new PayRequest(PayMethodType.CARD, ConvenienceType.G25, 50);
         PayResponse payResponse = conveniencePayService.pay(payRequest);
 
         System.out.println(payResponse);

--- a/src/main/java/com/zerobase/convpay/config/ApplicationConfig.java
+++ b/src/main/java/com/zerobase/convpay/config/ApplicationConfig.java
@@ -1,0 +1,28 @@
+package com.zerobase.convpay.config;
+
+import com.zerobase.convpay.service.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class ApplicationConfig {
+
+    public ConveniencePayService conveniencePayServiceDiscountPayMethod(){
+        return new ConveniencePayService(
+                new HashSet<>(
+                        Arrays.asList(new MoneyAdaptor(), new CardAdaptor())
+                ),
+                new DiscountByPayMethod()
+        );
+    }
+
+    public ConveniencePayService conveniencePayServiceDiscountConvenience(){
+        return new ConveniencePayService(
+                new HashSet<>(
+                        Arrays.asList(new MoneyAdaptor(), new CardAdaptor())
+                ),
+                new DiscountByConvenience()
+        );
+    }
+
+}

--- a/src/main/java/com/zerobase/convpay/service/CardAdaptor.java
+++ b/src/main/java/com/zerobase/convpay/service/CardAdaptor.java
@@ -1,9 +1,6 @@
 package com.zerobase.convpay.service;
 
-import com.zerobase.convpay.type.CancelPaymentResult;
-import com.zerobase.convpay.type.CardUseCancelResult;
-import com.zerobase.convpay.type.CardUseResult;
-import com.zerobase.convpay.type.PaymentResult;
+import com.zerobase.convpay.type.*;
 
 public class CardAdaptor implements PaymentInterface {
     //1.인증
@@ -30,6 +27,11 @@ public class CardAdaptor implements PaymentInterface {
             return CardUseCancelResult.USE_CANCEL_FAIL;
         }
         return CardUseCancelResult.USE_CANCEL_SUCCESS;
+    }
+
+    @Override
+    public PayMethodType getPayMethodType() {
+        return PayMethodType.CARD;
     }
 
     @Override

--- a/src/main/java/com/zerobase/convpay/service/MoneyAdaptor.java
+++ b/src/main/java/com/zerobase/convpay/service/MoneyAdaptor.java
@@ -1,9 +1,6 @@
 package com.zerobase.convpay.service;
 
-import com.zerobase.convpay.type.CancelPaymentResult;
-import com.zerobase.convpay.type.MoneyUseCancelResult;
-import com.zerobase.convpay.type.MoneyUseResult;
-import com.zerobase.convpay.type.PaymentResult;
+import com.zerobase.convpay.type.*;
 
 public class MoneyAdaptor implements PaymentInterface {
     public MoneyUseResult use(Integer payAmount){
@@ -25,6 +22,11 @@ public class MoneyAdaptor implements PaymentInterface {
 
         return MoneyUseCancelResult.MONEY_USE_CANCEL_SUCCESS;
 
+    }
+
+    @Override
+    public PayMethodType getPayMethodType() {
+        return PayMethodType.MONEY;
     }
 
     @Override

--- a/src/main/java/com/zerobase/convpay/service/PaymentInterface.java
+++ b/src/main/java/com/zerobase/convpay/service/PaymentInterface.java
@@ -1,9 +1,11 @@
 package com.zerobase.convpay.service;
 
 import com.zerobase.convpay.type.CancelPaymentResult;
+import com.zerobase.convpay.type.PayMethodType;
 import com.zerobase.convpay.type.PaymentResult;
 
 public interface PaymentInterface {
+     PayMethodType getPayMethodType();
      PaymentResult payment(Integer payAmount);
      CancelPaymentResult cancelPayment(Integer cancelAmount);
 }

--- a/src/test/java/com/zerobase/convpay/service/ConveniencePayServiceTest.java
+++ b/src/test/java/com/zerobase/convpay/service/ConveniencePayServiceTest.java
@@ -10,11 +10,19 @@ import com.zerobase.convpay.type.PayMethodType;
 import com.zerobase.convpay.type.PayResult;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class ConveniencePayServiceTest {
 
-    ConveniencePayService conveniencePayService = new ConveniencePayService();
+    ConveniencePayService conveniencePayService = new ConveniencePayService(
+            new HashSet<>(
+                    Arrays.asList(new MoneyAdaptor(), new CardAdaptor())
+            ),
+            new DiscountByPayMethod()
+    );
 
     @Test
     void pay_success() throws Exception {


### PR DESCRIPTION
- 구현체를 ConveniencePayService가 아닌 ApplicationConfig에서 들게하기
- 이제 ConveniencePayService는 구현체가 아니라 인터페이스만 들고있게됨
- UserClient도 conveniencePayService를 만들어서 사용이아니라, applicationConfig만 이용해서 전체 어플리케이션을 사용할 수 있게됨